### PR TITLE
Refactor webpack.common.js

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -13,8 +13,6 @@ module.exports = {
     publicPath: '/',
   },
   plugins: [
-    // it exchanges, adds, or removes modules while an application is running without a page reload.
-    new webpack.HotModuleReplacementPlugin(),
     // it Automatically load modules instead of having to import or require them everywhere
     new webpack.ProvidePlugin({
       $: 'jquery',

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,3 +1,4 @@
+const webpack = require('webpack');
 const merge = require('webpack-merge');
 const common = require('./webpack.common.js');
 
@@ -6,4 +7,8 @@ module.exports = merge(common, {
   // devtools helps to control if and how source maps are generated
   // inline-source-map  transformed code are (lines only)
   devtool: 'inline-source-map',
+  plugins: [
+    // it exchanges, adds, or removes modules while an application is running without a page reload.
+    new webpack.HotModuleReplacementPlugin(),
+  ]
 });


### PR DESCRIPTION
#### Description
Move webpack hotmodule replacement pluging to webpack.dev.js

#### What does this PR do?
it refactor webpack.common.js by moving hot module replacement pluging to webpack.dev.js

#### Any background context you want to provide?
None
#### Types of changes
- [x] Bug fix ( fix an issue in webpack.common.js)
